### PR TITLE
add DAY_NAMES constant instead of ::Time::RFC2822_DAY_NAME

### DIFF
--- a/lib/business_time/config.rb
+++ b/lib/business_time/config.rb
@@ -186,13 +186,18 @@ module BusinessTime
 
       private
 
+      DAY_NAMES = [
+        'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'
+      ]
+      private_constant :DAY_NAMES
+
       def wday_to_int day_name
-        lowercase_day_names = ::Time::RFC2822_DAY_NAME.map(&:downcase)
+        lowercase_day_names = DAY_NAMES.map(&:downcase)
         lowercase_day_names.find_index(day_name.to_s.downcase)
       end
 
       def int_to_wday num
-        ::Time::RFC2822_DAY_NAME.map(&:downcase).map(&:to_sym)[num]
+        DAY_NAMES.map(&:downcase).map(&:to_sym)[num]
       end
 
       def reset


### PR DESCRIPTION
Fixes [#211](https://github.com/bokmann/business_time/issues/211)

before
```ruby
$ ruby -v
ruby 3.1.0preview1 (2021-11-09 master 5a3b2e6141) [x86_64-darwin20]
$ bundle exec rake
EEEEEEEEEEEEEEEEEE.E.E..E..EEEEEEEEEEEEEEEEEEE...EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE......EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.......EEEEEEEEEEEEEEEEEEEEEEEE........EEEEEEEEEEEEEEEE.E......EEEEEEEEEEEEEEEEEEEEEEEE.EEEEEEEEEE...

  1) Error:
time extensions#test_0007_calculate business time between different times on the same date (counter clockwise):
NameError: uninitialized constant Time::RFC2822_DAY_NAME

        ::Time::RFC2822_DAY_NAME.map(&:downcase).map(&:to_sym)[num]
              ^^^^^^^^^^^^^^^^^^
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/config.rb:195:in `int_to_wday'
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/config.rb:124:in `beginning_of_workday'
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/time_extensions.rb:29:in `beginning_of_workday'
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/time_extensions.rb:47:in `before_business_hours?'
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/time_extensions.rb:58:in `roll_forward'
    /Users/yuya.tani/Work/8.oss/business_time/lib/business_time/time_extensions.rb:152:in `business_time_until'
    /Users/yuya.tani/Work/8.oss/business_time/test/test_time_extensions.rb:51:in `block (2 levels) in <top (required)>'
・
・
・
247 runs, 130 assertions, 0 failures, 206 errors, 0 skips
```

after
```ruby
$ ruby -v
ruby 3.1.0preview1 (2021-11-09 master 5a3b2e6141) [x86_64-darwin20]
$ bundle exec rake
............................................................................................................................................................................................................
...........................................

Finished in 0.247837s, 996.6228 runs/s, 1557.4753 assertions/s.

247 runs, 386 assertions, 0 failures, 0 errors, 0 skips
```